### PR TITLE
v3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/vendor
+/.idea
+/.vagrant
+/.phpstorm.*
+composer.lock
+.phpunit.result.cache

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,7 @@
 
 * [Installation](getting-started/installation.md)
 * [Configuration](getting-started/configuration.md)
+* [Upgrade Guide](getting-started/upgrade-guide.md)
 
 ## 😎 The Basics <a href="#basics" id="basics"></a>
 

--- a/basics/creating-dto-instances.md
+++ b/basics/creating-dto-instances.md
@@ -37,6 +37,16 @@ public function store(Request $request): JsonResponse
 }
 ```
 
+Starting in **v3**, you can also use the DTO as it was a **Form Request** class, so instead of manually creating the DTO instance,
+you can type-hint the DTO in the controller method, and it will be automatically created for you:
+
+```php
+public function store(UserDTO $dto): JsonResponse
+{
+    // ...
+}
+```
+
 ### From Eloquent Models
 
 ```php

--- a/basics/generating-dtos.md
+++ b/basics/generating-dtos.md
@@ -21,3 +21,16 @@ property in the `config/dto.php` file:
 
 'namespace' => 'App\\DTOs',
 ```
+
+Compared to v2, the generated DTO from v3 is more simple and only contains the most used methods:
+
+- `rules()` (For Validated DTOs only)
+- `defaults()`
+- `casts()`
+
+If you want to customize further your DTO add the missing methods when needed.
+
+- `messages()`
+- `attributes()`
+- `mapData()`
+- `mapToTransform()`

--- a/basics/generating-dtos.md
+++ b/basics/generating-dtos.md
@@ -6,4 +6,18 @@ You can create `DTOs` using the `make:dto` command:
 php artisan make:dto UserDTO
 ```
 
-The `DTOs` are going to be created inside `app/DTOs`.
+The `DTOs` are going to be created inside `app/DTOs` by default. You can customize the path by updating the namespace
+property in the `config/dto.php` file:
+
+```php
+/*
+|--------------------------------------------------------------------------
+| NAMESPACE
+|--------------------------------------------------------------------------
+|
+| The namespace where your DTOs will be created.
+|
+*/
+
+'namespace' => 'App\\DTOs',
+```

--- a/basics/mapping-dto-properties.md
+++ b/basics/mapping-dto-properties.md
@@ -2,10 +2,10 @@
 
 ### Mapping data before validation
 
-Sometimes the data you have to validate is not the same as you want in your DTO. You can use the `mapBeforeValidation` method to map your data before the validation and the DTO instantiation occurs:
+Sometimes the data you have to validate is not the same as you want in your DTO. You can use the `mapData` method to map your data before the validation and the DTO instantiation occurs:
 
 ```php
-protected function mapBeforeValidation(): array
+protected function mapData(): array
 {
     return [
         'full_name' => 'name',
@@ -47,10 +47,10 @@ But in your Request, the data comes like this:
 ]
 ```
 
-You can add this to the `mapBeforeValidation` method:
+You can add this to the `mapData` method:
 
 ```php
-protected function mapBeforeValidation(): array
+protected function mapData(): array
 {
     return [
         'first_name' => 'name.first_name',
@@ -61,12 +61,12 @@ protected function mapBeforeValidation(): array
 
 This way, the `first_name` and `last_name` properties will be mapped to the `name.first_name` and `name.last_name` properties of your request.
 
-### Mapping data before export
+### Mapping data before transforming
 
-Sometimes the data you have in your DTO is not the same as you want in your Model, Array, or JSON. You can use the `mapBeforeExport` method to map your data before exporting your DTO to another structure:
+Sometimes the data you have in your DTO is not the same you want to your Model, Array, JSON. You can use the `mapToTransform` method to map your data before transforming your DTO to another structure:
 
 ```php
-protected function mapBeforeExport(): array
+protected function mapToTransform(): array
 {
     return [
         'name' => 'username',
@@ -74,7 +74,7 @@ protected function mapBeforeExport(): array
 }
 ```
 
-The code above will map the `name` property to the `username` property before exporting your DTO to another structure. So the resulting structure will have a `username` property instead of a `name` property.
+The code above will map the `name` property to the `username` property before transforming your DTO to another structure. So the resulting structure will have a `username` property instead of a `name` property.
 
 #### **Mapping nested data to flat data**
 
@@ -109,10 +109,10 @@ class User extends Model
 }
 ```
 
-You can add this to the `mapBeforeExport` method:
+You can add this to the `mapToTransform` method:
 
 ```php
-protected function mapBeforeExport(): array
+protected function mapToTransform(): array
 {
     return [
         'name.first_name' => 'first_name',
@@ -123,4 +123,4 @@ protected function mapBeforeExport(): array
 
 This way, when calling the `toModel` method, the `name.first_name` and `name.last_name` properties of your DTO will be mapped to the `first_name` and `last_name` properties of your Model.
 
-You can combine both methods to map your data before validation and before export. If you combine both examples above your request will have a `full_name` property, your DTO will have a `name` property and when exported the result will have a `username` property.
+You can combine both methods to map your data before validation and before transformation. If you combine both examples above your request will have a `full_name` property, your DTO will have a `name` property and when transformed the result will have a `username` property.

--- a/basics/simple-dtos.md
+++ b/basics/simple-dtos.md
@@ -20,14 +20,14 @@ class SimpleUserDTO extends SimpleDTO
             'age' => new IntegerCast(),
         ];
     }
-    protected function mapBeforeValidation(): array
+    protected function mapData(): array
     {
         return [
             'username' => 'name',
             'user_email' => 'email',
         ];
     }
-    protected function mapBeforeExport(): array
+    protected function mapToTransform(): array
     {
         return [
             'name' => 'customer_name',

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -12,6 +12,18 @@ The configuration file will look like this:
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | NAMESPACE
+    |--------------------------------------------------------------------------
+    |
+    | The namespace where your DTOs will be created.
+    |
+    */
+
+    'namespace' => 'App\\DTOs',
+
     /*
     |--------------------------------------------------------------------------
     | REQUIRE CASTING
@@ -22,6 +34,7 @@ return [
     | \WendellAdriel\ValidatedDTO\Exceptions\MissingCastTypeException exception
     |
     */
+
     'require_casting' => false,
 ];
 ```

--- a/getting-started/upgrade-guide.md
+++ b/getting-started/upgrade-guide.md
@@ -1,0 +1,47 @@
+# Upgrade Guide
+
+I tried to maintain backward compatibility as much as possible, but there are some breaking changes while
+upgrading from v2 to v3.
+
+## Configuration
+
+If you published the config file before, or if you want to customize the path/namespace used to generate your DTOs,
+you'll need to merge the new config file with your old one or publish it. This is the new config file:
+
+```php
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | NAMESPACE
+    |--------------------------------------------------------------------------
+    |
+    | The namespace where your DTOs will be created.
+    |
+    */
+
+    'namespace' => 'App\\DTOs',
+
+    /*
+    |--------------------------------------------------------------------------
+    | REQUIRE CASTING
+    |--------------------------------------------------------------------------
+    |
+    | If this is set to true, you must configure a cast type for all properties of your DTOs.
+    | If a property doesn't have a cast type configured it will throw a
+    | \WendellAdriel\ValidatedDTO\Exceptions\MissingCastTypeException exception
+    |
+    */
+
+    'require_casting' => false,
+];
+```
+
+## Mapping DTO data
+
+The methods used to map the DTO data were renamed to be more accurate:
+
+- `mapBeforeValidation()` was renamed to `mapData()`
+- `mapBeforeExport()` was renamed to `mapToTransform()`

--- a/type-casting/available-types.md
+++ b/type-casting/available-types.md
@@ -13,6 +13,20 @@ protected function casts(): array
 }
 ```
 
+If you want to cast all the elements inside the array, you can pass a `Castable` to the `ArrayCast`
+constructor. Let's say that you want to convert all the items inside the array into integers:
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new ArrayCast(new IntegerCast()),
+    ];
+}
+```
+
+This works with all `Castable`, including `DTOCast` and `ModelCast` for nested data.
+
 ### Boolean <a href="#boolean" id="boolean"></a>
 
 For string values, this uses the `filter_var` function with the `FILTER_VALIDATE_BOOLEAN` flag.
@@ -137,6 +151,24 @@ protected function casts(): array
 {
     return [
         'property' => new DTOCast(UserDTO::class),
+    ];
+}
+```
+
+### Enum <a href="#enum" id="enum"></a>
+
+This will try to convert the value to the given `Enum` class. It works with `UnitEnum` and `BackedEnum`.
+
+This will throw a `WendellAdriel\ValidatedDTO\Exceptions\CastException` exception if the property is not a valid enum value.
+
+This will throw a `WendellAdriel\ValidatedDTO\Exceptions\CastTargetException` exception if the class passed to the
+`EnumCast` constructor is not a `Enum` instance.
+
+```php
+protected function casts(): array
+{
+    return [
+        'property' => new EnumCast(MyEnum::class),
     ];
 }
 ```


### PR DESCRIPTION
## New Features

- Use **DTO** as it was a **Form Request**
- Ability to customize the path/namespace of the generated DTOs
- DTO classes generated with the make command are more slim
- Ability to cast array items when using the `ArrayCast`
- New `EnumCast` for casting values to Enums. Work with `UnitEnum` and `BackedEnum`

## Breaking Changes

- `mapBeforeValidation()` was renamed to `mapData()`
- `mapBeforeExport()` was renamed to `mapToTransform()`